### PR TITLE
Create tests for BaseModel

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,6 +1,4 @@
 preset: psr2
 finder:
-  exclude:
-    - "tests"
   name:
     - "*.php"

--- a/src/Models/BaseModel.php
+++ b/src/Models/BaseModel.php
@@ -6,7 +6,7 @@ abstract class BaseModel
     public function __construct($attributes)
     {
         foreach ($attributes as $key => $value) {
-            if (!property_exists(self, $key)) {
+            if (!property_exists($this, $key)) {
                 continue;
             }
 

--- a/tests/Unit/Services/Gateways/BaseModelTest.php
+++ b/tests/Unit/Services/Gateways/BaseModelTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use Ebanx\Benjamin\Models\BaseModel;
+
+class SubModel extends BaseModel {
+    public $foo;
+}
+
+class BaseModelTest extends TestCase
+{
+    /**
+     * A basic test example.
+     *
+     * @return void
+     */
+    public function testConstructor()
+    {
+        $testData = [
+            'foo' => 'bar',
+            'baz' => 'qux'
+        ];
+        $subModel = new SubModel($testData);
+
+        $this->assertObjectHasAttribute('foo', $subModel);
+        $this->assertTrue($subModel->foo === $testData['foo']);
+        $this->assertObjectNotHasAttribute('baz', $subModel);
+    }
+}

--- a/tests/Unit/Services/Gateways/BaseModelTest.php
+++ b/tests/Unit/Services/Gateways/BaseModelTest.php
@@ -5,11 +5,6 @@ namespace Tests\Unit;
 use Tests\TestCase;
 use Ebanx\Benjamin\Models\BaseModel;
 
-class SubModel extends BaseModel
-{
-    public $foo;
-}
-
 class BaseModelTest extends TestCase
 {
     /**
@@ -23,10 +18,15 @@ class BaseModelTest extends TestCase
             'foo' => 'bar',
             'baz' => 'qux'
         ];
-        $subModel = new SubModel($testData);
+        $subModel = new BaseModelImplementation($testData);
 
         $this->assertObjectHasAttribute('foo', $subModel);
-        $this->assertTrue($subModel->foo === $testData['foo']);
+        $this->assertEquals('bar', $subModel->foo);
         $this->assertObjectNotHasAttribute('baz', $subModel);
     }
+}
+
+class BaseModelImplementation extends BaseModel
+{
+    public $foo;
 }

--- a/tests/Unit/Services/Gateways/BaseModelTest.php
+++ b/tests/Unit/Services/Gateways/BaseModelTest.php
@@ -5,7 +5,8 @@ namespace Tests\Unit;
 use Tests\TestCase;
 use Ebanx\Benjamin\Models\BaseModel;
 
-class SubModel extends BaseModel {
+class SubModel extends BaseModel
+{
     public $foo;
 }
 


### PR DESCRIPTION
I needed to replace `self` with `$this` because we were getting this error:
```
Use of undefined constant self - assumed 'self'
 /Users/guilherme/Code/EBANX/benjamin/src/Models/BaseModel.php:9
```