### PR TITLE
Changing how benjamin is called

### DIFF
--- a/main.php
+++ b/main.php
@@ -4,8 +4,10 @@ namespace
     use Ebanx\Benjamin\Main;
     use Ebanx\Benjamin\Models\Configs\Config;
 
-    function Benjamin(Config $config)
-    {
-        return new Main($config);
+    if (!function_exists('EBANX')) {
+        function EBANX(Config $config)
+        {
+            return new Main($config);
+        }
     }
 }

--- a/src/Facades/Gateways.php
+++ b/src/Facades/Gateways.php
@@ -6,20 +6,13 @@ use Ebanx\Benjamin\Services\Gateways as Services;
 
 class Gateways
 {
-    private $config;
-
-    public function __construct(Config $config)
+    public static function boleto(Config $config)
     {
-        $this->config = $config;
+        return new Services\Boleto($config);
     }
 
-    public function boleto()
+    public static function creditCard(Config $config)
     {
-        return new Services\Boleto($this->config);
-    }
-
-    public function creditCard()
-    {
-        return new Services\CreditCard($this->config);
+        return new Services\CreditCard($config);
     }
 }

--- a/src/Main.php
+++ b/src/Main.php
@@ -3,6 +3,8 @@ namespace Ebanx\Benjamin;
 
 use Ebanx\Benjamin\Models\Configs\Config;
 use Ebanx\Benjamin\Facades;
+use Ebanx\Benjamin\Models\Payment;
+use Psr\Log\InvalidArgumentException;
 
 class Main
 {
@@ -13,8 +15,12 @@ class Main
         $this->config = $config;
     }
 
-    public function gateways()
+    public function create(Payment $payment)
     {
-        return new Facades\Gateways($this->config);
+        if (!method_exists('Ebanx\Benjamin\Facades\Gateways', $payment->type)) {
+            throw new InvalidArgumentException('Invalid payment type');
+        }
+        $instance = call_user_func(array('Ebanx\Benjamin\Facades\Gateways', $payment->type), $this->config);
+        return $instance->create($payment);
     }
 }

--- a/src/Main.php
+++ b/src/Main.php
@@ -23,13 +23,4 @@ class Main
         $instance = call_user_func(array('Ebanx\Benjamin\Facades\Gateways', $payment->type), $this->config);
         return $instance->create($payment);
     }
-
-    public function create(Payment $payment)
-    {
-        if (!method_exists('Ebanx\Benjamin\Facades\Gateways', $payment->type)) {
-            throw new InvalidArgumentException('Invalid payment type');
-        }
-        $instance = call_user_func(array('Ebanx\Benjamin\Facades\Gateways', $payment->type), $this->config);
-        return $instance->create($payment);
-    }
 }

--- a/src/Models/Payment.php
+++ b/src/Models/Payment.php
@@ -74,6 +74,13 @@ class Payment extends BaseModel
      */
     public $responsible;
 
+    /**
+     * The payment method type
+     *
+     * @var string
+     */
+    public $type;
+
 #EFT Boleto Baloto
     /**
      * Expiry date of the payment.

--- a/tests/Helpers/Builders/PaymentBuilder.php
+++ b/tests/Helpers/Builders/PaymentBuilder.php
@@ -31,6 +31,7 @@ class PaymentBuilder extends BaseBuilder
 
     public function boleto()
     {
+        $this->instance->type = 'boleto';
         $this->instance->currencyCode = Currency::BRL;
         $this->instance->dueDate = $this->faker->dateTimeBetween('+1 days', '+3 days');
 
@@ -39,6 +40,7 @@ class PaymentBuilder extends BaseBuilder
 
     public function creditCard($instalmentNumber = 1)
     {
+        $this->instance->type = 'creditcard';
         $this->instance->currencyCode = Currency::BRL;
         $this->instance->card = $this->faker->cardModel();
         $this->instance->instalments = $instalmentNumber;

--- a/tests/Unit/Services/Gateways/BoletoTest.php
+++ b/tests/Unit/Services/Gateways/BoletoTest.php
@@ -13,7 +13,7 @@ class BoletoTest extends TestGateway
 
         $payment = BuilderFactory::payment()->boleto()->businessPerson()->build();
         AbstractGatewayForTests::setClient($client);
-        $result = Benjamin($this->config)->gateways()->boleto()->create($payment);
+        $result = EBANX($this->config)->create($payment);
 
         $this->assertArrayHasKey('payment', $result);
 

--- a/tests/Unit/Services/Gateways/CreditCardTest.php
+++ b/tests/Unit/Services/Gateways/CreditCardTest.php
@@ -13,7 +13,7 @@ class CreditCardTest extends TestGateway
 
         $payment = BuilderFactory::payment()->creditCard()->businessPerson()->build();
         AbstractGatewayForTests::setClient($client);
-        $result = Benjamin($this->config)->gateways()->creditCard()->create($payment);
+        $result = EBANX($this->config)->create($payment);
 
         $this->assertArrayHasKey('payment', $result);
 


### PR DESCRIPTION
Make the developer interface more friendly to avoid misuse of the API

Before:
```php
$result = Benjamin($config)->gateways()->boleto()->create($payment);
```

After:
```php
$result = EBANX($this->config)->create($payment);
```