### PR TITLE
[t-sLt7vHW1] Removing code style check from test-all script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "test": "phpunit",
         "test-only": "phpunit --filter",
         "dup-check": "phpcpd src && phpcpd tests",
-        "test-all": "composer test && composer style-check && composer dup-check",
+        "test-all": "composer test && composer dup-check",
         "style-check" : "php-cs-fixer fix --dry-run --verbose --diff ./",
         "style-fix" : "php-cs-fixer fix --verbose ./"
     }


### PR DESCRIPTION
The command `php-cs-fixer fix --dry-run --verbose --diff ./ ` was failing in build step on travis for php 5.4 due to error on friendsofphp/php-cs-fixer package.