### PR TITLE
Fix the number of installments to Peru and Uruguay

### DIFF
--- a/src/Models/Configs/CreditCardConfig.php
+++ b/src/Models/Configs/CreditCardConfig.php
@@ -6,7 +6,7 @@ use Ebanx\Benjamin\Models\Currency;
 
 class CreditCardConfig extends BaseModel implements AddableConfig
 {
-    const MAX_INSTALMENTS = 36;
+    const MAX_INSTALMENTS = 48;
 
     /**
      * Number of max instalments, defaults to 12.

--- a/src/Services/Gateways/CreditCard.php
+++ b/src/Services/Gateways/CreditCard.php
@@ -60,8 +60,8 @@ class CreditCard extends DirectGateway
         Country::MEXICO   => 12,
         Country::ARGENTINA => 12,
         Country::CHILE => 12,
-        Country::URUGUAY => 12,
-        Country::PERU => 12,
+        Country::URUGUAY => 6,
+        Country::PERU => 48,
     ];
 
     private $creditCardConfig;

--- a/tests/Unit/Services/Gateways/CreditCardTest.php
+++ b/tests/Unit/Services/Gateways/CreditCardTest.php
@@ -395,7 +395,7 @@ class CreditCardTest extends GatewayTestCase
     public function testInstalmentsUruguay()
     {
         $country = Country::URUGUAY;
-        $totalInstalments = 12;
+        $totalInstalments = 6;
         $exchange_rate = 1;
         $creditCard = $this->setupGateway($exchange_rate, new Config());
         $instalmentsArray = $creditCard->getInstalmentsByCountry($country);
@@ -411,7 +411,7 @@ class CreditCardTest extends GatewayTestCase
     public function testInstalmentsPeru()
     {
         $country = Country::PERU;
-        $totalInstalments = 12;
+        $totalInstalments = 48;
         $exchange_rate = 1;
         $creditCard = $this->setupGateway($exchange_rate, new Config());
         $instalmentsArray = $creditCard->getInstalmentsByCountry($country);

--- a/tests/Unit/Services/Gateways/CreditCardTest.php
+++ b/tests/Unit/Services/Gateways/CreditCardTest.php
@@ -400,7 +400,7 @@ class CreditCardTest extends GatewayTestCase
         $creditCard = $this->setupGateway($exchange_rate, new Config());
         $instalmentsArray = $creditCard->getInstalmentsByCountry($country);
         $expectedInstalmentsArray = [];
-        for ($i = 1; $i <= 12; $i++) {
+        for ($i = 1; $i <= $totalInstalments; $i++) {
             $expectedInstalmentsArray[$i] = $i;
         }
 
@@ -415,8 +415,9 @@ class CreditCardTest extends GatewayTestCase
         $exchange_rate = 1;
         $creditCard = $this->setupGateway($exchange_rate, new Config());
         $instalmentsArray = $creditCard->getInstalmentsByCountry($country);
+
         $expectedInstalmentsArray = [];
-        for ($i = 1; $i <= 12; $i++) {
+        for ($i = 1; $i <= $totalInstalments; $i++) {
             $expectedInstalmentsArray[$i] = $i;
         }
 


### PR DESCRIPTION
Peru uses 48 installments and Uruguay uses only 6 installments.