### PR TITLE
Add digital wallets

### DIFF
--- a/src/Facade.php
+++ b/src/Facade.php
@@ -1,20 +1,22 @@
 <?php
+
 namespace Ebanx\Benjamin;
 
+use Ebanx\Benjamin\Models\Configs\AddableConfig;
 use Ebanx\Benjamin\Models\Configs\Config;
 use Ebanx\Benjamin\Models\Configs\CreditCardConfig;
-use Ebanx\Benjamin\Models\Configs\AddableConfig;
 use Ebanx\Benjamin\Models\Payment;
+use Ebanx\Benjamin\Models\Wallet;
 use Ebanx\Benjamin\Services\CancelPayment;
-use Ebanx\Benjamin\Services\Gateways;
-use Ebanx\Benjamin\Services\PaymentInfo;
 use Ebanx\Benjamin\Services\Exchange;
-use Ebanx\Benjamin\Services\Refund;
+use Ebanx\Benjamin\Services\Gateways;
 use Ebanx\Benjamin\Services\Http\Client as HttpClient;
+use Ebanx\Benjamin\Services\PaymentInfo;
+use Ebanx\Benjamin\Services\Refund;
 
 class Facade
 {
-    const VERSION="1.25.0";
+    const VERSION = "1.25.0";
     /**
      * Mock this in your tests extending and using ClientForTests
      * and any Engine you like (we provide EchoEngine)
@@ -34,6 +36,7 @@ class Facade
 
     /**
      * @param AddableConfig $config,... Configuration objects
+     *
      * @return Facade
      */
     public function addConfig(AddableConfig $config)
@@ -41,7 +44,7 @@ class Facade
         $args = func_get_args();
         foreach ($args as $config) {
             $class = $config->getShortClassName();
-            call_user_func([$this, 'with'.$class], $config);
+            call_user_func([$this, 'with' . $class], $config);
         }
 
         return $this;
@@ -49,26 +52,31 @@ class Facade
 
     /**
      * @param Config $config
+     *
      * @return Facade
      */
     public function withConfig(Config $config)
     {
         $this->config = $config;
+
         return $this;
     }
 
     /**
      * @param CreditCardConfig $creditCardConfig
+     *
      * @return Facade
      */
     public function withCreditCardConfig(CreditCardConfig $creditCardConfig)
     {
         $this->creditCardConfig = $creditCardConfig;
+
         return $this;
     }
 
     /**
      * @param Payment $payment
+     *
      * @return array
      * @throws \InvalidArgumentException
      */
@@ -78,16 +86,18 @@ class Facade
             throw new \InvalidArgumentException('Invalid payment type');
         }
 
-        if (!method_exists($this, $payment->type)) {
+        if (! method_exists($this, $payment->type)) {
             throw new \InvalidArgumentException('Invalid payment type');
         }
 
         $instance = call_user_func([$this, $payment->type]);
+
         return $instance->create($payment);
     }
 
     /**
      * @param string $hash
+     *
      * @return string
      */
     public function getTicketHtml($hash)
@@ -95,12 +105,12 @@ class Facade
         $info = $this->paymentInfo()->findByHash($hash);
 
         $gatewayName = $this->getGatewayNameFromType($info['payment']['payment_type_code']);
-        if (!$gatewayName) {
+        if (! $gatewayName) {
             return null;
         }
 
         $gateway = $this->{$gatewayName}();
-        if (!method_exists($gateway, 'getTicketHtml')) {
+        if (! method_exists($gateway, 'getTicketHtml')) {
             return null;
         }
 
@@ -169,7 +179,8 @@ class Facade
     }
 
     /**
-     * @param  CreditCardConfig $creditCardConfig (optional) credit card config
+     * @param CreditCardConfig $creditCardConfig (optional) credit card config
+     *
      * @return Gateways\CreditCard
      */
     public function creditCard(CreditCardConfig $creditCardConfig = null)
@@ -235,6 +246,46 @@ class Facade
     public function tef()
     {
         return new Gateways\Tef($this->config, $this->getHttpClient());
+    }
+
+    /**
+     * @return Gateways\Wallet\MACHPay
+     */
+    public function walletMACHPay()
+    {
+        return new Gateways\Wallet\MACHPay($this->config, $this->getHttpClient());
+    }
+
+    /**
+     * @return Gateways\Wallet\MercadoPago
+     */
+    public function walletMercadoPago()
+    {
+        return new Gateways\Wallet\MercadoPago($this->config, $this->getHttpClient());
+    }
+
+    /**
+     * @return Gateways\Wallet\Nequi
+     */
+    public function walletNequi()
+    {
+        return new Gateways\Wallet\Nequi($this->config, $this->getHttpClient());
+    }
+
+    /**
+     * @return Gateways\Wallet\PayPal
+     */
+    public function walletPaypal()
+    {
+        return new Gateways\Wallet\PayPal($this->config, $this->getHttpClient());
+    }
+
+    /**
+     * @return Gateways\Wallet\Picpay
+     */
+    public function walletPicpay()
+    {
+        return new Gateways\Wallet\Picpay($this->config, $this->getHttpClient());
     }
 
     /**
@@ -369,6 +420,7 @@ class Facade
             $this->httpClient = new HttpClient();
             $this->httpClient->switchMode($this->config->isSandbox);
         }
+
         return $this->httpClient;
     }
 
@@ -377,7 +429,7 @@ class Facade
         foreach ($this->getAllPublicServices() as $method => $service) {
             $class = get_class($service);
 
-            if (!defined($class.'::API_TYPE')) {
+            if (! defined($class . '::API_TYPE')) {
                 continue;
             }
 
@@ -399,8 +451,8 @@ class Facade
         foreach ($methods as $method) {
             $reflection = new \ReflectionMethod($this, $method);
 
-            if (!$reflection->isPublic()
-                || $reflection->getNumberOfRequiredParameters() > 0) {
+            if (! $reflection->isPublic()
+                 || $reflection->getNumberOfRequiredParameters() > 0) {
                 continue;
             }
 

--- a/src/Models/Payment.php
+++ b/src/Models/Payment.php
@@ -136,4 +136,11 @@ class Payment extends BaseModel
      *  Flag to use `Under Review` risk analysis tool.
      */
     public $manualReview = null;
+
+    /**
+     * Digital wallet - a.k.a. MercadoPago, PayPal, Picpay, MACH Pay, Nequi, etc.
+     *
+     * @var string
+     */
+    public $wallet;
 }

--- a/src/Models/Wallet.php
+++ b/src/Models/Wallet.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Ebanx\Benjamin\Models;
+
+class Wallet extends BaseModel
+{
+    const MERCADOPAGO = 'mercadopago';
+    const PAYPAL = 'paypal';
+    const PICPAY = 'picpay';
+    const MACH_PAY = 'machpay';
+    const NEQUI = 'nequi';
+
+    public static function localForCountry($country)
+    {
+        if (! in_array($country, Country::all())) {
+            return null;
+        }
+
+        $relation = [
+            Country::ARGENTINA => [self::MERCADOPAGO],
+            Country::BRAZIL    => [self::MERCADOPAGO, self::PAYPAL, self::PICPAY],
+            Country::CHILE     => [self::MACH_PAY],
+            Country::COLOMBIA  => [self::NEQUI],
+            Country::MEXICO    => [self::MERCADOPAGO]
+        ];
+
+        return $relation[$country];
+    }
+}

--- a/src/Services/Adapters/Wallet/MACHPayPaymentAdapter.php
+++ b/src/Services/Adapters/Wallet/MACHPayPaymentAdapter.php
@@ -1,0 +1,16 @@
+<?php
+namespace Ebanx\Benjamin\Services\Adapters\Wallet;
+
+use Ebanx\Benjamin\Models\Wallet;
+use Ebanx\Benjamin\Services\Adapters\BrazilPaymentAdapter;
+
+class MACHPayPaymentAdapter extends BrazilPaymentAdapter
+{
+    protected function transformPayment()
+    {
+        $transformed = parent::transformPayment();
+        $transformed->payment_type_code = Wallet::MACH_PAY;
+
+        return $transformed;
+    }
+}

--- a/src/Services/Adapters/Wallet/MercadoPagoPaymentAdapter.php
+++ b/src/Services/Adapters/Wallet/MercadoPagoPaymentAdapter.php
@@ -1,0 +1,16 @@
+<?php
+namespace Ebanx\Benjamin\Services\Adapters\Wallet;
+
+use Ebanx\Benjamin\Models\Wallet;
+use Ebanx\Benjamin\Services\Adapters\BrazilPaymentAdapter;
+
+class MercadoPagoPaymentAdapter extends BrazilPaymentAdapter
+{
+    protected function transformPayment()
+    {
+        $transformed = parent::transformPayment();
+        $transformed->payment_type_code = Wallet::MERCADOPAGO;
+
+        return $transformed;
+    }
+}

--- a/src/Services/Adapters/Wallet/NequiPaymentAdapter.php
+++ b/src/Services/Adapters/Wallet/NequiPaymentAdapter.php
@@ -1,0 +1,16 @@
+<?php
+namespace Ebanx\Benjamin\Services\Adapters\Wallet;
+
+use Ebanx\Benjamin\Models\Wallet;
+use Ebanx\Benjamin\Services\Adapters\BrazilPaymentAdapter;
+
+class NequiPaymentAdapter extends BrazilPaymentAdapter
+{
+    protected function transformPayment()
+    {
+        $transformed = parent::transformPayment();
+        $transformed->payment_type_code = Wallet::NEQUI;
+
+        return $transformed;
+    }
+}

--- a/src/Services/Adapters/Wallet/PayPalPaymentAdapter.php
+++ b/src/Services/Adapters/Wallet/PayPalPaymentAdapter.php
@@ -1,0 +1,16 @@
+<?php
+namespace Ebanx\Benjamin\Services\Adapters\Wallet;
+
+use Ebanx\Benjamin\Models\Wallet;
+use Ebanx\Benjamin\Services\Adapters\BrazilPaymentAdapter;
+
+class PayPalPaymentAdapter extends BrazilPaymentAdapter
+{
+    protected function transformPayment()
+    {
+        $transformed = parent::transformPayment();
+        $transformed->payment_type_code = Wallet::PAYPAL;
+
+        return $transformed;
+    }
+}

--- a/src/Services/Adapters/Wallet/PicpayPaymentAdapter.php
+++ b/src/Services/Adapters/Wallet/PicpayPaymentAdapter.php
@@ -1,0 +1,16 @@
+<?php
+namespace Ebanx\Benjamin\Services\Adapters\Wallet;
+
+use Ebanx\Benjamin\Models\Wallet;
+use Ebanx\Benjamin\Services\Adapters\BrazilPaymentAdapter;
+
+class PicpayPaymentAdapter extends BrazilPaymentAdapter
+{
+    protected function transformPayment()
+    {
+        $transformed = parent::transformPayment();
+        $transformed->payment_type_code = Wallet::PICPAY;
+
+        return $transformed;
+    }
+}

--- a/src/Services/Gateways/Wallet/MACHPay.php
+++ b/src/Services/Gateways/Wallet/MACHPay.php
@@ -1,0 +1,34 @@
+<?php
+namespace Ebanx\Benjamin\Services\Gateways\Wallet;
+
+use Ebanx\Benjamin\Models\Country;
+use Ebanx\Benjamin\Models\Currency;
+use Ebanx\Benjamin\Models\Payment;
+use Ebanx\Benjamin\Services\Adapters\Wallet\MACHPayPaymentAdapter;
+use Ebanx\Benjamin\Services\Gateways\DirectGateway;
+
+class MACHPay extends DirectGateway
+{
+    const API_TYPE = 'wallet';
+
+    protected static function getEnabledCountries()
+    {
+        return [Country::CHILE];
+    }
+
+    protected static function getEnabledCurrencies()
+    {
+        return [
+            Currency::CLP,
+            Currency::USD,
+            Currency::EUR,
+        ];
+    }
+
+    protected function getPaymentData(Payment $payment)
+    {
+        $adapter = new MACHPayPaymentAdapter($payment, $this->config);
+
+        return $adapter->transform();
+    }
+}

--- a/src/Services/Gateways/Wallet/MercadoPago.php
+++ b/src/Services/Gateways/Wallet/MercadoPago.php
@@ -1,0 +1,40 @@
+<?php
+namespace Ebanx\Benjamin\Services\Gateways\Wallet;
+
+use Ebanx\Benjamin\Models\Country;
+use Ebanx\Benjamin\Models\Currency;
+use Ebanx\Benjamin\Models\Payment;
+use Ebanx\Benjamin\Services\Adapters\Wallet\MercadoPagoPaymentAdapter;
+use Ebanx\Benjamin\Services\Gateways\DirectGateway;
+
+class MercadoPago extends DirectGateway
+{
+    const API_TYPE = 'wallet';
+
+    protected static function getEnabledCountries()
+    {
+        return [
+            Country::ARGENTINA,
+            Country::BRAZIL,
+            Country::MEXICO
+        ];
+    }
+
+    protected static function getEnabledCurrencies()
+    {
+        return [
+            Currency::ARS,
+            Currency::BRL,
+            Currency::MXN,
+            Currency::USD,
+            Currency::EUR,
+        ];
+    }
+
+    protected function getPaymentData(Payment $payment)
+    {
+        $adapter = new MercadoPagoPaymentAdapter($payment, $this->config);
+
+        return $adapter->transform();
+    }
+}

--- a/src/Services/Gateways/Wallet/Nequi.php
+++ b/src/Services/Gateways/Wallet/Nequi.php
@@ -1,0 +1,34 @@
+<?php
+namespace Ebanx\Benjamin\Services\Gateways\Wallet;
+
+use Ebanx\Benjamin\Models\Country;
+use Ebanx\Benjamin\Models\Currency;
+use Ebanx\Benjamin\Models\Payment;
+use Ebanx\Benjamin\Services\Adapters\Wallet\NequiPaymentAdapter;
+use Ebanx\Benjamin\Services\Gateways\DirectGateway;
+
+class Nequi extends DirectGateway
+{
+    const API_TYPE = 'wallet';
+
+    protected static function getEnabledCountries()
+    {
+        return [Country::COLOMBIA];
+    }
+
+    protected static function getEnabledCurrencies()
+    {
+        return [
+            Currency::COP,
+            Currency::USD,
+            Currency::EUR,
+        ];
+    }
+
+    protected function getPaymentData(Payment $payment)
+    {
+        $adapter = new NequiPaymentAdapter($payment, $this->config);
+
+        return $adapter->transform();
+    }
+}

--- a/src/Services/Gateways/Wallet/PayPal.php
+++ b/src/Services/Gateways/Wallet/PayPal.php
@@ -1,0 +1,34 @@
+<?php
+namespace Ebanx\Benjamin\Services\Gateways\Wallet;
+
+use Ebanx\Benjamin\Models\Country;
+use Ebanx\Benjamin\Models\Currency;
+use Ebanx\Benjamin\Models\Payment;
+use Ebanx\Benjamin\Services\Adapters\Wallet\PayPalPaymentAdapter;
+use Ebanx\Benjamin\Services\Gateways\DirectGateway;
+
+class PayPal extends DirectGateway
+{
+    const API_TYPE = 'wallet';
+
+    protected static function getEnabledCountries()
+    {
+        return [Country::BRAZIL];
+    }
+
+    protected static function getEnabledCurrencies()
+    {
+        return [
+            Currency::BRL,
+            Currency::USD,
+            Currency::EUR,
+        ];
+    }
+
+    protected function getPaymentData(Payment $payment)
+    {
+        $adapter = new PayPalPaymentAdapter($payment, $this->config);
+
+        return $adapter->transform();
+    }
+}

--- a/src/Services/Gateways/Wallet/Picpay.php
+++ b/src/Services/Gateways/Wallet/Picpay.php
@@ -1,0 +1,34 @@
+<?php
+namespace Ebanx\Benjamin\Services\Gateways\Wallet;
+
+use Ebanx\Benjamin\Models\Country;
+use Ebanx\Benjamin\Models\Currency;
+use Ebanx\Benjamin\Models\Payment;
+use Ebanx\Benjamin\Services\Adapters\Wallet\PicpayPaymentAdapter;
+use Ebanx\Benjamin\Services\Gateways\DirectGateway;
+
+class Picpay extends DirectGateway
+{
+    const API_TYPE = 'wallet';
+
+    protected static function getEnabledCountries()
+    {
+        return [Country::BRAZIL];
+    }
+
+    protected static function getEnabledCurrencies()
+    {
+        return [
+            Currency::BRL,
+            Currency::USD,
+            Currency::EUR,
+        ];
+    }
+
+    protected function getPaymentData(Payment $payment)
+    {
+        $adapter = new PicpayPaymentAdapter($payment, $this->config);
+
+        return $adapter->transform();
+    }
+}

--- a/tests/Helpers/Builders/PaymentBuilder.php
+++ b/tests/Helpers/Builders/PaymentBuilder.php
@@ -2,6 +2,7 @@
 namespace Tests\Helpers\Builders;
 
 use Ebanx\Benjamin\Models\Card;
+use Ebanx\Benjamin\Models\Wallet;
 use Faker;
 use Ebanx\Benjamin\Models\Bank;
 use Ebanx\Benjamin\Models\Payment;
@@ -100,6 +101,14 @@ class PaymentBuilder extends BaseBuilder
     {
         $this->instance->type = 'tef';
         $this->instance->bankCode = Bank::BANCO_DO_BRASIL;
+
+        return $this;
+    }
+
+    public function wallet()
+    {
+        $this->instance->type = 'wallet';
+        $this->instance->wallet = Wallet::PAYPAL;
 
         return $this;
     }

--- a/tests/Unit/Services/Gateways/Wallet/MACHPayTest.php
+++ b/tests/Unit/Services/Gateways/Wallet/MACHPayTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Unit\Services\Gateways\Wallet;
+
+use Ebanx\Benjamin\Models\Configs\Config;
+use Ebanx\Benjamin\Models\Country;
+use Ebanx\Benjamin\Models\Currency;
+use Ebanx\Benjamin\Services\Gateways\Wallet\MACHPay;
+use Tests\Helpers\Builders\BuilderFactory;
+use Tests\Unit\Services\Gateways\WalletTestCase;
+
+class MACHPayTest extends WalletTestCase
+{
+    public function testPayment()
+    {
+        $walletSuccessfulResponse = $this->getDigitalWalletSuccessfulResponseJson();
+        $client = $this->getMockedClient($walletSuccessfulResponse);
+
+        $factory = new BuilderFactory('es_CL');
+        $payment = $factory->payment()->wallet()->build();
+        $gateway = new MACHPay($this->config, $client);
+
+        $result = $gateway->create($payment);
+
+        $this->assertArrayHasKey('payment', $result);
+        $this->assertArrayHasKey('redirect_url', $result);
+        // TODO: assert output (to be defined)
+    }
+
+    public function testAvailabilityWithUSDEUR()
+    {
+        $gateway = new MACHPay($this->config);
+        $expectedCountries = [
+            Country::CHILE,
+        ];
+
+        $this->assertAvailableForCountries($gateway, $expectedCountries);
+    }
+
+    public function testAvailabilityWithLocalCurrency()
+    {
+        $gateway = new MACHPay(new Config([
+            'baseCurrency' => Currency::CLP,
+        ]));
+
+        $this->assertAvailableForCountries($gateway, [
+            Country::CHILE,
+        ]);
+    }
+
+    public function testAvailabilityWithWrongLocalCurrency()
+    {
+        $gateway = new MACHPay(new Config([
+            'baseCurrency' => Currency::BOB,
+        ]));
+
+        $this->assertNotAvailableAnywhere($gateway);
+    }
+}

--- a/tests/Unit/Services/Gateways/Wallet/MercadoPagoTest.php
+++ b/tests/Unit/Services/Gateways/Wallet/MercadoPagoTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Unit\Services\Gateways\Wallet;
+
+use Ebanx\Benjamin\Models\Configs\Config;
+use Ebanx\Benjamin\Models\Country;
+use Ebanx\Benjamin\Models\Currency;
+use Ebanx\Benjamin\Services\Gateways\Wallet\MercadoPago;
+use Tests\Helpers\Builders\BuilderFactory;
+use Tests\Unit\Services\Gateways\WalletTestCase;
+
+class MercadoPagoTest extends WalletTestCase
+{
+    public function testPayment()
+    {
+        $walletSuccessfulResponse = $this->getDigitalWalletSuccessfulResponseJson();
+        $client = $this->getMockedClient($walletSuccessfulResponse);
+
+        $factory = new BuilderFactory('pt_BR');
+        $payment = $factory->payment()->wallet()->build();
+        $gateway = new MercadoPago($this->config, $client);
+
+        $result = $gateway->create($payment);
+
+        $this->assertArrayHasKey('payment', $result);
+        $this->assertArrayHasKey('redirect_url', $result);
+        // TODO: assert output (to be defined)
+    }
+
+    public function testAvailabilityWithUSDEUR()
+    {
+        $gateway = new MercadoPago($this->config);
+        $expectedCountries = [
+            Country::ARGENTINA,
+            Country::BRAZIL,
+            Country::MEXICO
+        ];
+
+        $this->assertAvailableForCountries($gateway, $expectedCountries);
+    }
+
+    public function testAvailabilityWithLocalCurrency()
+    {
+        $gateway = new MercadoPago(new Config([
+            'baseCurrency' => Currency::ARS,
+        ]));
+
+        $this->assertAvailableForCountries($gateway, [
+            Country::ARGENTINA
+        ]);
+
+        $gateway = new MercadoPago(new Config([
+            'baseCurrency' => Currency::BRL,
+        ]));
+
+        $this->assertAvailableForCountries($gateway, [
+            Country::BRAZIL
+        ]);
+
+        $gateway = new MercadoPago(new Config([
+            'baseCurrency' => Currency::MXN,
+        ]));
+
+        $this->assertAvailableForCountries($gateway, [
+            Country::MEXICO
+        ]);
+    }
+
+    public function testAvailabilityWithWrongLocalCurrency()
+    {
+        $gateway = new MercadoPago(new Config([
+            'baseCurrency' => Currency::BOB,
+        ]));
+
+        $this->assertNotAvailableAnywhere($gateway);
+    }
+}

--- a/tests/Unit/Services/Gateways/Wallet/NequiTest.php
+++ b/tests/Unit/Services/Gateways/Wallet/NequiTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Unit\Services\Gateways\Wallet;
+
+use Ebanx\Benjamin\Models\Configs\Config;
+use Ebanx\Benjamin\Models\Country;
+use Ebanx\Benjamin\Models\Currency;
+use Ebanx\Benjamin\Services\Gateways\Wallet\Nequi;
+use Tests\Helpers\Builders\BuilderFactory;
+use Tests\Unit\Services\Gateways\WalletTestCase;
+
+class NequiTest extends WalletTestCase
+{
+    public function testPayment()
+    {
+        $walletSuccessfulResponse = $this->getDigitalWalletSuccessfulResponseJson();
+        $client = $this->getMockedClient($walletSuccessfulResponse);
+
+        $factory = new BuilderFactory('es_CO');
+        $payment = $factory->payment()->wallet()->build();
+        $gateway = new Nequi($this->config, $client);
+
+        $result = $gateway->create($payment);
+
+        $this->assertArrayHasKey('payment', $result);
+        $this->assertArrayHasKey('redirect_url', $result);
+        // TODO: assert output (to be defined)
+    }
+
+    public function testAvailabilityWithUSDEUR()
+    {
+        $gateway = new Nequi($this->config);
+        $expectedCountries = [
+            Country::COLOMBIA,
+        ];
+
+        $this->assertAvailableForCountries($gateway, $expectedCountries);
+    }
+
+    public function testAvailabilityWithLocalCurrency()
+    {
+        $gateway = new Nequi(new Config([
+            'baseCurrency' => Currency::COP,
+        ]));
+
+        $this->assertAvailableForCountries($gateway, [
+            Country::COLOMBIA,
+        ]);
+    }
+
+    public function testAvailabilityWithWrongLocalCurrency()
+    {
+        $gateway = new Nequi(new Config([
+            'baseCurrency' => Currency::BOB,
+        ]));
+
+        $this->assertNotAvailableAnywhere($gateway);
+    }
+}

--- a/tests/Unit/Services/Gateways/Wallet/PayPalTest.php
+++ b/tests/Unit/Services/Gateways/Wallet/PayPalTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Unit\Services\Gateways\Wallet;
+
+use Ebanx\Benjamin\Models\Configs\Config;
+use Ebanx\Benjamin\Models\Country;
+use Ebanx\Benjamin\Models\Currency;
+use Ebanx\Benjamin\Services\Gateways\Wallet\PayPal;
+use Tests\Helpers\Builders\BuilderFactory;
+use Tests\Unit\Services\Gateways\WalletTestCase;
+
+class PayPalTest extends WalletTestCase
+{
+    public function testPayment()
+    {
+        $walletSuccessfulResponse = $this->getDigitalWalletSuccessfulResponseJson();
+        $client = $this->getMockedClient($walletSuccessfulResponse);
+
+        $factory = new BuilderFactory('pt_BR');
+        $payment = $factory->payment()->wallet()->build();
+        $gateway = new PayPal($this->config, $client);
+
+        $result = $gateway->create($payment);
+
+        $this->assertArrayHasKey('payment', $result);
+        $this->assertArrayHasKey('redirect_url', $result);
+        // TODO: assert output (to be defined)
+    }
+
+    public function testAvailabilityWithUSDEUR()
+    {
+        $gateway = new PayPal($this->config);
+        $expectedCountries = [
+            Country::BRAZIL,
+        ];
+
+        $this->assertAvailableForCountries($gateway, $expectedCountries);
+    }
+
+    public function testAvailabilityWithLocalCurrency()
+    {
+        $gateway = new PayPal(new Config([
+            'baseCurrency' => Currency::BRL,
+        ]));
+
+        $this->assertAvailableForCountries($gateway, [
+            Country::BRAZIL,
+        ]);
+    }
+
+    public function testAvailabilityWithWrongLocalCurrency()
+    {
+        $gateway = new PayPal(new Config([
+            'baseCurrency' => Currency::BOB,
+        ]));
+
+        $this->assertNotAvailableAnywhere($gateway);
+    }
+}

--- a/tests/Unit/Services/Gateways/Wallet/PicPayTest.php
+++ b/tests/Unit/Services/Gateways/Wallet/PicPayTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Unit\Services\Gateways\Wallet;
+
+use Ebanx\Benjamin\Models\Configs\Config;
+use Ebanx\Benjamin\Models\Country;
+use Ebanx\Benjamin\Models\Currency;
+use Ebanx\Benjamin\Services\Gateways\Wallet\Picpay;
+use Tests\Helpers\Builders\BuilderFactory;
+use Tests\Unit\Services\Gateways\WalletTestCase;
+
+class PicpayTest extends WalletTestCase
+{
+    public function testPayment()
+    {
+        $walletSuccessfulResponse = $this->getDigitalWalletSuccessfulResponseJson();
+        $client = $this->getMockedClient($walletSuccessfulResponse);
+
+        $factory = new BuilderFactory('pt_BR');
+        $payment = $factory->payment()->wallet()->build();
+        $gateway = new Picpay($this->config, $client);
+
+        $result = $gateway->create($payment);
+
+        $this->assertArrayHasKey('payment', $result);
+        $this->assertArrayHasKey('redirect_url', $result);
+        // TODO: assert output (to be defined)
+    }
+
+    public function testAvailabilityWithUSDEUR()
+    {
+        $gateway = new Picpay($this->config);
+        $expectedCountries = [
+            Country::BRAZIL,
+        ];
+
+        $this->assertAvailableForCountries($gateway, $expectedCountries);
+    }
+
+    public function testAvailabilityWithLocalCurrency()
+    {
+        $gateway = new Picpay(new Config([
+            'baseCurrency' => Currency::BRL,
+        ]));
+
+        $this->assertAvailableForCountries($gateway, [
+            Country::BRAZIL,
+        ]);
+    }
+
+    public function testAvailabilityWithWrongLocalCurrency()
+    {
+        $gateway = new Picpay(new Config([
+            'baseCurrency' => Currency::BOB,
+        ]));
+
+        $this->assertNotAvailableAnywhere($gateway);
+    }
+}

--- a/tests/Unit/Services/Gateways/WalletTestCase.php
+++ b/tests/Unit/Services/Gateways/WalletTestCase.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Unit\Services\Gateways;
+
+use Ebanx\Benjamin\Models\Configs\Config;
+use Ebanx\Benjamin\Models\Country;
+use Ebanx\Benjamin\Models\Currency;
+use Ebanx\Benjamin\Services\Gateways\Wallet;
+use Tests\Helpers\Builders\BuilderFactory;
+
+class WalletTestCase extends GatewayTestCase
+{
+    public function getDigitalWalletSuccessfulResponseJson()
+    {
+        return '{"payment":{"hash":"5ec27f3b86fa8e3123452345626aec3989aa2ceccdb7","pin":"237274394","country":"co","merchant_payment_code":"xyz-123-1001","order_number":null,"status":"PE","status_date":null,"open_date":"2020-05-18 12:27:38","confirm_date":null,"transfer_date":null,"amount_br":"1.00","amount_ext":"1.00","amount_iof":"0.00","currency_rate":"1.0000","currency_ext":"COP","due_date":"2020-05-21","instalments":"1","payment_type_code":"nequi","redirect_url":"https://api.ebanx.com/ws/redirect/execute?hash=5ec27f3b86fa8e318ddcc9727453626aec3989aa2ceccdb7","pre_approved":false,"capture_available":null},"status":"SUCCESS","redirect_url":"https://api.ebanx.com/ws/redirect/execute?hash=5ec27f3b86fa8e318dd345234523553626aec3989aa2ceccdb7"}';
+    }
+}


### PR DESCRIPTION
Add digital wallets as payment available to Argentina, Brazil, Chile, Colombia, and Mexico