### PR TITLE
[t-tzV1UZda] Add Guatemala and Paraguay to credit/debit cards

### DIFF
--- a/src/Models/Configs/CreditCardConfig.php
+++ b/src/Models/Configs/CreditCardConfig.php
@@ -40,6 +40,8 @@ class CreditCardConfig extends BaseModel implements AddableConfig
             Currency::CLP => 1,
             Currency::UYU => 1,
             Currency::PEN => 1,
+            Currency::PYG => 1,
+            Currency::GTQ => 1,
         ];
 
         return isset($relation[$currency])

--- a/src/Models/Country.php
+++ b/src/Models/Country.php
@@ -8,7 +8,9 @@ class Country extends BaseModel
     const CHILE = 'Chile';
     const COLOMBIA = 'Colombia';
     const ECUADOR = 'Ecuador';
+    const GUATEMALA = 'Guatemala';
     const MEXICO = 'Mexico';
+    const PARAGUAY = 'Paraguay';
     const PERU = 'Peru';
     const BOLIVIA = 'Bolivia';
     const URUGUAY = 'Uruguay';
@@ -24,7 +26,9 @@ class Country extends BaseModel
             self::CHILE,
             self::COLOMBIA,
             self::ECUADOR,
+            self::GUATEMALA,
             self::MEXICO,
+            self::PARAGUAY,
             self::PERU,
             self::BOLIVIA,
             self::URUGUAY,
@@ -71,7 +75,9 @@ class Country extends BaseModel
             'CL' => self::CHILE,
             'CO' => self::COLOMBIA,
             'EC' => self::ECUADOR,
+            'GT' => self::GUATEMALA,
             'MX' => self::MEXICO,
+            'PY' => self::PARAGUAY,
             'PE' => self::PERU,
             'BO' => self::BOLIVIA,
             'UY' => self::URUGUAY,

--- a/src/Models/Currency.php
+++ b/src/Models/Currency.php
@@ -13,6 +13,8 @@ class Currency extends BaseModel
     const PEN = 'PEN';
     const BOB = 'BOB';
     const UYU = 'UYU';
+    const GTQ = 'GTQ';
+    const PYG = 'PYG';
 
     public static function all()
     {
@@ -27,6 +29,8 @@ class Currency extends BaseModel
             self::PEN,
             self::BOB,
             self::UYU,
+            self::GTQ,
+            self::PYG,
         ];
     }
 
@@ -50,7 +54,9 @@ class Currency extends BaseModel
             Country::CHILE => self::CLP,
             Country::COLOMBIA => self::COP,
             Country::ECUADOR => self::USD,
+            Country::GUATEMALA => self::GTQ,
             Country::MEXICO => self::MXN,
+            Country::PARAGUAY => self::PYG,
             Country::PERU => self::PEN,
             Country::BOLIVIA => self::BOB,
             Country::URUGUAY => self::UYU,

--- a/src/Services/Gateways/CreditCard.php
+++ b/src/Services/Gateways/CreditCard.php
@@ -26,6 +26,8 @@ class CreditCard extends DirectGateway
             Country::CHILE,
             Country::URUGUAY,
             Country::PERU,
+            Country::PARAGUAY,
+            Country::GUATEMALA,
         ];
     }
 
@@ -41,6 +43,8 @@ class CreditCard extends DirectGateway
             Currency::CLP,
             Currency::UYU,
             Currency::PEN,
+            Currency::GTQ,
+            Currency::PYG,
         ];
     }
 
@@ -52,6 +56,8 @@ class CreditCard extends DirectGateway
         Country::CHILE => 1,
         Country::URUGUAY => 1,
         Country::PERU => 1,
+        Country::PARAGUAY => 1,
+        Country::GUATEMALA => 3,
     ];
 
     public static $maxInstalmentCountry = [
@@ -62,6 +68,8 @@ class CreditCard extends DirectGateway
         Country::CHILE => 12,
         Country::URUGUAY => 6,
         Country::PERU => 48,
+        Country::PARAGUAY => 12,
+        Country::GUATEMALA => 12,
     ];
 
     private $creditCardConfig;

--- a/src/Services/Gateways/DebitCard.php
+++ b/src/Services/Gateways/DebitCard.php
@@ -15,6 +15,8 @@ class DebitCard extends DirectGateway
         return [
             Country::MEXICO,
             Country::URUGUAY,
+            Country::PARAGUAY,
+            Country::GUATEMALA,
         ];
     }
     protected static function getEnabledCurrencies()
@@ -24,6 +26,8 @@ class DebitCard extends DirectGateway
             Currency::USD,
             Currency::EUR,
             Currency::UYU,
+            Currency::GTQ,
+            Currency::PYG,
         ];
     }
 

--- a/tests/Unit/Models/CountryTest.php
+++ b/tests/Unit/Models/CountryTest.php
@@ -15,6 +15,8 @@ class CountryTest extends TestCase
         $this->assertEquals(Country::ECUADOR, Country::fromIso('EC'));
         $this->assertEquals(Country::MEXICO, Country::fromIso('MX'));
         $this->assertEquals(Country::PERU, Country::fromIso('PE'));
+        $this->assertEquals(Country::GUATEMALA, Country::fromIso('GT'));
+        $this->assertEquals(Country::PARAGUAY, Country::fromIso('PY'));
         $this->assertNull(Country::fromIso('ZZ'));
     }
 
@@ -27,6 +29,8 @@ class CountryTest extends TestCase
         $this->assertEquals('EC', Country::toIso(Country::ECUADOR));
         $this->assertEquals('MX', Country::toIso(Country::MEXICO));
         $this->assertEquals('PE', Country::toIso(Country::PERU));
+        $this->assertEquals('GT', Country::toIso(Country::GUATEMALA));
+        $this->assertEquals('PY', Country::toIso(Country::PARAGUAY));
         $this->assertNull(Country::toIso('Ebanxland'));
     }
 }

--- a/tests/Unit/Services/Gateways/CreditCardTest.php
+++ b/tests/Unit/Services/Gateways/CreditCardTest.php
@@ -72,7 +72,9 @@ class CreditCardTest extends GatewayTestCase
             Country::ARGENTINA,
             Country::CHILE,
             Country::URUGUAY,
-            Country::PERU
+            Country::PERU,
+            Country::PARAGUAY,
+            Country::GUATEMALA
         ];
 
         $this->assertAvailableForCountries($gateway, $expectedCountries);
@@ -412,6 +414,43 @@ class CreditCardTest extends GatewayTestCase
     {
         $country = Country::PERU;
         $totalInstalments = 48;
+        $exchange_rate = 1;
+        $creditCard = $this->setupGateway($exchange_rate, new Config());
+        $instalmentsArray = $creditCard->getInstalmentsByCountry($country);
+
+        $expectedInstalmentsArray = [];
+        for ($i = 1; $i <= $totalInstalments; $i++) {
+            $expectedInstalmentsArray[$i] = $i;
+        }
+
+        $this->assertEquals($totalInstalments, count($instalmentsArray));
+        $this->assertEquals($expectedInstalmentsArray, $instalmentsArray);
+    }
+
+    public function testInstalmentsGuatemala()
+    {
+        $country = Country::GUATEMALA;
+        $totalInstalments = 6;
+        $exchange_rate = 1;
+        $creditCard = $this->setupGateway($exchange_rate, new Config());
+        $instalmentsArray = $creditCard->getInstalmentsByCountry($country);
+
+        $expectedInstalmentsArray = array(
+            '1' => '1',
+            '2' => '2',
+            '3' => '3',
+            '6' => '6',
+            '9' => '9',
+            '12' => '12');
+
+
+        $this->assertEquals($totalInstalments, count($instalmentsArray));
+        $this->assertEquals($expectedInstalmentsArray, $instalmentsArray);
+    }
+    public function testInstalmentsParaguay()
+    {
+        $country = Country::PARAGUAY;
+        $totalInstalments = 12;
         $exchange_rate = 1;
         $creditCard = $this->setupGateway($exchange_rate, new Config());
         $instalmentsArray = $creditCard->getInstalmentsByCountry($country);

--- a/tests/Unit/Services/Gateways/DebitCardTest.php
+++ b/tests/Unit/Services/Gateways/DebitCardTest.php
@@ -35,6 +35,8 @@ class DebitCardTest extends GatewayTestCase
         $this->assertAvailableForCountries($gateway, [
             Country::MEXICO,
             Country::URUGUAY,
+            Country::PARAGUAY,
+            Country::GUATEMALA
         ]);
 
         $gateway = new DebitCard(new Config([
@@ -44,6 +46,8 @@ class DebitCardTest extends GatewayTestCase
         $this->assertAvailableForCountries($gateway, [
             Country::MEXICO,
             Country::URUGUAY,
+            Country::PARAGUAY,
+            Country::GUATEMALA,
         ]);
     }
 


### PR DESCRIPTION
Adding support for Credit Card and Debit Card payment methods for Paraguay and Guatemala